### PR TITLE
add TDHelpers and changes in WoT-Definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/.vs
 **/bin
 **/obj
+.DS_Store

--- a/TDHelpers/README.md
+++ b/TDHelpers/README.md
@@ -1,0 +1,23 @@
+Validation example with Json.NET Schema https://www.newtonsoft.com/jsonschema
+
+'''
+
+        using Newtonsoft.Json.Schema;
+        
+        //change the directory with your TD.
+        var TDtxt = File.ReadAllText("Insert directory");
+
+        //change the directory with JSON Schema for TD.
+        string TDschema = File.ReadAllText("insert directory");
+
+        //Validation, requires Newtonsoft.Json.Schema to import
+        JSchema jsonSchema = JSchema.Parse(TDschema);
+        JObject TD = JObject.Parse(TDtxt); 
+        bool valid = TD.IsValid(jsonSchema);
+
+        if (valid)
+        {
+            var myJSONTD = JsonConvert.DeserializeObject<ThingDescription>(TDtxt);
+        }
+        else Console.WriteLine("Your TD file is not valid.");
+'''

--- a/TDHelpers/TDHelpers.sln
+++ b/TDHelpers/TDHelpers.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 25.0.1706.8
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDHelpers", "TDHelpers\TDHelpers.csproj", "{77263B10-596F-43B0-998E-AD90D8F90B06}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{77263B10-596F-43B0-998E-AD90D8F90B06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77263B10-596F-43B0-998E-AD90D8F90B06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77263B10-596F-43B0-998E-AD90D8F90B06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77263B10-596F-43B0-998E-AD90D8F90B06}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {CA0048FF-A1DB-4FFC-8F86-4B5C905356A8}
+	EndGlobalSection
+EndGlobal

--- a/TDHelpers/TDHelpers/TDHelpers.cs
+++ b/TDHelpers/TDHelpers/TDHelpers.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace TDHelpers
 {
 
-    //Converter to assign the correct DataSchema for a given schema
+    //Converter to assign the corresponding DataSchema for a given schema
     public class DataSchemaConverter : JsonConverter<DataSchema>
     {
 
@@ -202,7 +202,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to assign the correct SecurityScheme for a given schema
+    //Converter to assign the corresponding SecurityScheme for a given schema
     public class SecuritySchemeConverter : JsonConverter<SecurityScheme>
     {
 
@@ -276,7 +276,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to for Form in TD
+    //Converter for Form in TD
     public class FormConverter : JsonConverter<Form>
     {
 
@@ -333,7 +333,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to for PropertyForm 
+    //Converter for PropertyForm 
     public class PropertyFormConverter : JsonConverter<PropertyForm>
     {
 
@@ -396,7 +396,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to for ActionForm 
+    //Converter for ActionForm 
     public class ActionFormConverter : JsonConverter<ActionForm>
     {
 
@@ -461,7 +461,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to for EventForm 
+    //Converter for EventForm 
     public class EventFormConverter : JsonConverter<EventForm>
     {
 
@@ -578,7 +578,7 @@ namespace TDHelpers
 
     }
 
-    //Converter to assign the correct type for a given Op
+    //Called for properties that can be either string or string[], and it returns string[].
     public class StringTypeConverter : JsonConverter<string[]>
     {
 
@@ -635,7 +635,7 @@ namespace TDHelpers
         }
     }
 
-    //Converter to assign the correct type for a given Op
+    //Called for properties that can be either DataSchema or DataSchema[], and it returns DataSchema[].
     public class DataSchemaTypeConverter : JsonConverter<DataSchema[]>
     {
 
@@ -696,7 +696,7 @@ namespace TDHelpers
         }
     }
 
-    //Converter to assign the correct InteractionAffordance for a given schema
+    //Converter to assign the corresponding InteractionAffordance for a given schema
     public class InteractionAffordanceConverter : JsonConverter<InteractionAffordance>
     {
 

--- a/TDHelpers/TDHelpers/TDHelpers.cs
+++ b/TDHelpers/TDHelpers/TDHelpers.cs
@@ -1,0 +1,812 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using WoT_Definitions;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Schema;
+using System.Linq;
+
+namespace TDHelpers
+{
+
+    //Converter to assign the correct DataSchema for a given schema
+    public class DataSchemaConverter : JsonConverter<DataSchema>
+    {
+
+        public override void WriteJson(JsonWriter writer, DataSchema? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override DataSchema? ReadJson(JsonReader reader, Type objectType, DataSchema? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JsonReader reader2 = reader;
+            JToken schemaObj = JToken.Load(reader2);
+            if (schemaObj.Type == JTokenType.Null) return null;
+            string type = (string)schemaObj["type"]; //type of the given schema
+
+            switch (type)
+            {
+                case "object":
+                    return FillObjectSchemaObject(schemaObj, serializer);
+                case "array":
+                    return FillArraySchemaObject(schemaObj, serializer);
+                case "string":
+                    return FillStringSchemaObject(schemaObj, serializer);
+                case "boolean":
+                    return FillBooleanSchemaObject(schemaObj, serializer);
+                case "number":
+                    return FillNumberSchemaObject(schemaObj, serializer);
+                case "integer":
+                    return FillIntegerSchemaObject(schemaObj, serializer);
+                case "null":
+                    return FillNullSchemaObject(schemaObj, serializer);
+            }
+            return null;
+        }
+
+        public NumberSchema FillNumberSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            NumberSchema schema = new NumberSchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+
+            if (schemaObj["minimum"] != null) schema.Minimum = (double)schemaObj["minimum"];
+            if (schemaObj["maximum"] != null) schema.Maximum = (double)schemaObj["maximum"];
+            if (schemaObj["multipleOf"] != null) schema.MultipleOf = (double)schemaObj["multipleOf"];
+            if (schemaObj["exclusiveMinimum"] != null) schema.ExclusiveMinimum = (double)schemaObj["exclusiveMinimum"];
+            if (schemaObj["exclusiveMaximum"] != null) schema.ExclusiveMaximum = (double)schemaObj["exclusiveMaximum"];
+
+            // to make sure const, default, and enum types match the schema type they belong to
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"].ToObject<double>();
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"].ToObject<double>();
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<double[]>();
+
+
+            return schema;
+        }
+
+        public ArraySchema FillArraySchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            ArraySchema schema = new ArraySchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+            if (schemaObj["minItems"] != null) schema.MinItems = (uint)schemaObj["minItems"];
+            if (schemaObj["maxItems"] != null) schema.MaxItems = (uint)schemaObj["maxItems"];
+
+            if (schemaObj["items"] != null)
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new DataSchemaTypeConverter());
+                serializer = JsonSerializer.CreateDefault(settings);
+                schema.Items = serializer.Deserialize<DataSchema[]>(new JTokenReader(schemaObj["items"]));
+            }
+
+
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"];
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"];
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<Object[]>();
+
+            return schema;
+        }
+
+        public BooleanSchema FillBooleanSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            BooleanSchema schema = new BooleanSchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+            // to make sure const, default, and enum types match the schema type they belong to
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"].ToObject<bool>();
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"].ToObject<bool>();
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<bool[]>();
+
+            return schema;
+        }
+
+        //To Do: Throw an error if there is something wrong 
+
+        public IntegerSchema FillIntegerSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            IntegerSchema schema = new IntegerSchema();
+
+            CommonFiller(schema, schemaObj, serializer);
+
+
+            if (schemaObj["minimum"] != null) schema.Minimum = (int)schemaObj["minimum"];
+            if (schemaObj["maximum"] != null) schema.Maximum = (int)schemaObj["maximum"];
+            if (schemaObj["multipleOf"] != null) schema.MultipleOf = (int)schemaObj["multipleOf"];
+            if (schemaObj["exclusiveMinimum"] != null) schema.ExclusiveMinimum = (int)schemaObj["exclusiveMinimum"];
+            if (schemaObj["exclusiveMaximum"] != null) schema.ExclusiveMaximum = (int)schemaObj["exclusiveMaximum"];
+
+            // to make sure const, default, and enum types match the schema type they belong to
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"].ToObject<int>();
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"].ToObject<int>();
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<int[]>();
+
+            return schema;
+        }
+
+        public ObjectSchema FillObjectSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            ObjectSchema schema = new ObjectSchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+            if (schemaObj["required"] != null) schema.Required = schemaObj["required"].ToObject<string?[]>();
+            if (schemaObj["properties"] != null) schema.Properties = serializer.Deserialize(new JTokenReader(schemaObj["properties"]), objectType: typeof(Dictionary<string, DataSchema>)) as Dictionary<string, DataSchema>;
+
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"];
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"];
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<Object[]>();
+
+            return schema;
+        }
+
+        public StringSchema FillStringSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            StringSchema schema = new StringSchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+            schema.Pattern = (string?)schemaObj["pattern"];
+            schema.ContentEncoding = (string?)schemaObj["contentEncoding"];
+            schema.ContentMediaType = (string?)schemaObj["contentMediaType"];
+
+            if (schemaObj["minLength"] != null) schema.MinLength = (uint)schemaObj["minLength"];
+            if (schemaObj["maxLength"] != null) schema.MaxLength = (uint)schemaObj["maxLength"];
+
+            // to make sure const, default, and enum types match the schema type they belong to
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"].ToObject<string>();
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"].ToObject<string>();
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<string[]>();
+
+            return schema;
+        }
+
+        public NullSchema FillNullSchemaObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            NullSchema schema = new NullSchema();
+            CommonFiller(schema, schemaObj, serializer);
+
+
+            // to make sure const, default, and enum types match the schema type they belong to
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"];
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"];
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<Object[]>();
+            return schema;
+        }
+
+        // to fill the common properties of DataSchemas
+        public void CommonFiller(DataSchema schema, JToken schemaObj, JsonSerializer serializer)
+        {
+            schema.Description = (string?)schemaObj["description"];
+            schema.Title = (string?)schemaObj["title"];
+            schema.Unit = (string?)schemaObj["unit"];
+            schema.Format = (string?)schemaObj["format"];
+            if (schemaObj["readOnly"] != null) schema.ReadOnly = (bool)schemaObj["readOnly"];
+            if (schemaObj["writeOnly"] != null) schema.WriteOnly = (bool)schemaObj["writeOnly"];
+            if (schemaObj["titles"] != null) schema.Titles = schemaObj["titles"].ToObject<string?[]>();
+            if (schemaObj["descriptions"] != null) schema.Descriptions = schemaObj["descriptions"].ToObject<string?[]>();
+            if (schemaObj["allOf"] != null) schema.AllOf = serializer.Deserialize(new JTokenReader(schemaObj["allOf"]), objectType: typeof(DataSchema[])) as DataSchema[];
+            if (schemaObj["oneOf"] != null) schema.OneOf = serializer.Deserialize(new JTokenReader(schemaObj["oneOf"]), objectType: typeof(DataSchema[])) as DataSchema[];
+
+            if (schemaObj["@type"] != null)
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new StringTypeConverter());
+                serializer = JsonSerializer.CreateDefault(settings);
+                schema.AtType = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["@type"]));
+            }
+
+        }
+
+
+
+    }
+
+    //Converter to assign the correct SecurityScheme for a given schema
+    public class SecuritySchemeConverter : JsonConverter<SecurityScheme>
+    {
+
+        public override void WriteJson(JsonWriter writer, SecurityScheme? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override SecurityScheme? ReadJson(JsonReader reader, Type objectType, SecurityScheme? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+            string type = (string)schemaObj["scheme"];
+
+            switch (type)
+            {
+                case "nosec":
+                    return FillNoSecuritySchemeObject(schemaObj, serializer);
+                case "basic":
+                    return FillBasicSecuritySchemeObject(schemaObj, serializer);
+            }
+            return null;
+        }
+
+        public NoSecurityScheme FillNoSecuritySchemeObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            NoSecurityScheme schema = new NoSecurityScheme();
+            CommonFiller(schema, schemaObj, serializer);
+            return schema;
+        }
+
+        public BasicSecurityScheme FillBasicSecuritySchemeObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            BasicSecurityScheme schema = new BasicSecurityScheme();
+            CommonFiller(schema, schemaObj, serializer);
+
+
+            //assigning default value
+            schema.Name = (string?)schemaObj["name"];
+            if (schemaObj["in"] != null)
+            {
+                schema.In = (string?)schemaObj["in"];
+            }
+            else
+            {
+                schema.In = "header";
+            }
+
+
+            return schema;
+        }
+
+        // to fill the common properties of SecuritySchemas
+        public void CommonFiller(SecurityScheme schema, JToken schemaObj, JsonSerializer serializer)
+        {
+            schema.Description = (string?)schemaObj["description"];
+            schema.Scheme = (string?)schemaObj["scheme"];
+
+            if (schemaObj["@type"] != null)
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new StringTypeConverter());
+                serializer = JsonSerializer.CreateDefault(settings);
+                schema.AtType = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["@type"]));
+            }
+
+            if (schemaObj["descriptions"] != null) schema.Descriptions = schemaObj["descriptions"].ToObject<string?[]>();
+            if (schemaObj["proxy"] != null) schema.Proxy = schemaObj["proxy"].ToObject<Uri>();
+
+        }
+
+    }
+
+    //Converter to for Form in TD
+    public class FormConverter : JsonConverter<Form>
+    {
+
+        public override void WriteJson(JsonWriter writer, Form? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override Form? ReadJson(JsonReader reader, Type objectType, Form? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            //add default converter 
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new StringTypeConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+
+            Form schema = new Form();
+
+            if (schemaObj["href"] != null) schema.Href = schemaObj["href"].ToObject<Uri>();
+
+            if (schemaObj["contentType"] != null)
+            { schema.ContentType = schemaObj["contentType"].ToObject<string>(); }
+            else //Default value handling
+            {
+                schema.ContentType = "application/json";
+            }
+            schema.OriginalJson = schemaObj.ToString();
+            if (schemaObj["contentCoding"] != null) schema.ContentCoding = schemaObj["contentCoding"].ToObject<string>();
+            if (schemaObj["subprotocol"] != null) schema.Subprotocol = schemaObj["subprotocol"].ToObject<string>();
+            if (schemaObj["additionalExpectedResponse"] != null)
+            {
+                schema.AdditionalExpectedResponse = schemaObj["additionalExpectedResponse"].ToObject<AdditionalExpectedResponse>();
+            }
+            else
+            { //Default value handling
+                string contentType = schema.ContentType;
+                schema.AdditionalExpectedResponse = new AdditionalExpectedResponse(contentType);
+            }
+
+
+            if (schemaObj["security"] != null) schema.Security = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["security"]));
+
+            if (schemaObj["scopes"] != null) schema.Scopes = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["scopes"]));
+
+            if (schemaObj["op"] != null) schema.Op = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["op"]));
+
+
+
+            return schema;
+        }
+
+    }
+
+    //Converter to for PropertyForm 
+    public class PropertyFormConverter : JsonConverter<PropertyForm>
+    {
+
+        public override void WriteJson(JsonWriter writer, PropertyForm? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override PropertyForm? ReadJson(JsonReader reader, Type objectType, PropertyForm? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            //add default converter 
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new StringTypeConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+            JToken schemaObj = JToken.Load(reader);
+
+            if (schemaObj.Type == JTokenType.Null) return null;
+
+            PropertyForm schema = new PropertyForm();
+
+            if (schemaObj["href"] != null) schema.Href = schemaObj["href"].ToObject<Uri>();
+            if (schemaObj["contentType"] != null)
+            { schema.ContentType = schemaObj["contentType"].ToObject<string>(); }
+            else
+            {//Default value handling
+                schema.ContentType = "application/json";
+            }
+            if (schemaObj["contentCoding"] != null) schema.ContentCoding = schemaObj["contentCoding"].ToObject<string>();
+            if (schemaObj["subprotocol"] != null) schema.Subprotocol = schemaObj["subprotocol"].ToObject<string>();
+
+            if (schemaObj["additionalExpectedResponse"] != null)
+            {
+                schema.AdditionalExpectedResponse = schemaObj["additionalExpectedResponse"].ToObject<AdditionalExpectedResponse>();
+            }
+            else
+            {//Default value handling
+                string contentType = schema.ContentType;
+                schema.AdditionalExpectedResponse = new AdditionalExpectedResponse(contentType);
+            }
+
+            schema.OriginalJson = schemaObj.ToString();
+
+            if (schemaObj["security"] != null) schema.Security = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["security"]));
+
+            if (schemaObj["scopes"] != null) schema.Scopes = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["scopes"]));
+
+            if (schemaObj["op"] == null)
+            { //default value handling
+
+                //TODO: Default value of op needs to be handled here
+            }
+            else
+            {
+                schema.Op = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["op"]));
+            }
+
+            return schema;
+        }
+
+    }
+
+    //Converter to for ActionForm 
+    public class ActionFormConverter : JsonConverter<ActionForm>
+    {
+
+        public override void WriteJson(JsonWriter writer, ActionForm? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override ActionForm? ReadJson(JsonReader reader, Type objectType, ActionForm? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            //add default converter 
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new StringTypeConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+            JToken schemaObj = JToken.Load(reader);
+
+            if (schemaObj.Type == JTokenType.Null) return null;
+
+            ActionForm schema = new ActionForm();
+
+            if (schemaObj["href"] != null) schema.Href = schemaObj["href"].ToObject<Uri>();
+            if (schemaObj["contentType"] != null)
+            { schema.ContentType = schemaObj["contentType"].ToObject<string>(); }
+            else
+            {//Default value handling
+                schema.ContentType = "application/json";
+            }
+            if (schemaObj["contentCoding"] != null) schema.ContentCoding = schemaObj["contentCoding"].ToObject<string>();
+            if (schemaObj["subprotocol"] != null) schema.Subprotocol = schemaObj["subprotocol"].ToObject<string>();
+
+            if (schemaObj["additionalExpectedResponse"] != null)
+            {
+                schema.AdditionalExpectedResponse = schemaObj["additionalExpectedResponse"].ToObject<AdditionalExpectedResponse>();
+            }
+            else
+            {//Default value handling
+                string contentType = schema.ContentType;
+                schema.AdditionalExpectedResponse = new AdditionalExpectedResponse(contentType);
+            }
+
+            schema.OriginalJson = schemaObj.ToString();
+
+            if (schemaObj["security"] != null) schema.Security = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["security"]));
+
+            if (schemaObj["scopes"] != null) schema.Scopes = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["scopes"]));
+
+            if (schemaObj["op"] == null)
+            { //default value handling
+
+                string tmp = "invokeaction";
+                schema.Op = new string[1];
+                schema.Op[0] = tmp;
+            }
+            else
+            {
+                schema.Op = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["op"]));
+            }
+
+            return schema;
+        }
+
+    }
+
+    //Converter to for EventForm 
+    public class EventFormConverter : JsonConverter<EventForm>
+    {
+
+        public override void WriteJson(JsonWriter writer, EventForm? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override EventForm? ReadJson(JsonReader reader, Type objectType, EventForm? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            //add default converter 
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new StringTypeConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+
+            JToken schemaObj = JToken.Load(reader);
+
+            if (schemaObj.Type == JTokenType.Null) return null;
+
+            EventForm schema = new EventForm();
+
+            if (schemaObj["href"] != null) schema.Href = schemaObj["href"].ToObject<Uri>();
+            if (schemaObj["contentType"] != null)
+            { schema.ContentType = schemaObj["contentType"].ToObject<string>(); }
+            else
+            {//Default value handling
+                schema.ContentType = "application/json";
+            }
+            if (schemaObj["contentCoding"] != null) schema.ContentCoding = schemaObj["contentCoding"].ToObject<string>();
+            if (schemaObj["subprotocol"] != null) schema.Subprotocol = schemaObj["subprotocol"].ToObject<string>();
+
+            if (schemaObj["additionalExpectedResponse"] != null)
+            {
+                schema.AdditionalExpectedResponse = schemaObj["additionalExpectedResponse"].ToObject<AdditionalExpectedResponse>();
+            }
+            else
+            {//Default value handling
+                string contentType = schema.ContentType;
+                schema.AdditionalExpectedResponse = new AdditionalExpectedResponse(contentType);
+            }
+
+            schema.OriginalJson = schemaObj.ToString();
+
+            if (schemaObj["security"] != null) schema.Security = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["security"]));
+
+            if (schemaObj["scopes"] != null) schema.Scopes = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["scopes"]));
+
+            if (schemaObj["op"] == null)
+            { //default value handling
+
+                string[] temp = { "subscribeevent", "unsubscribeevent" };
+                schema.Op = temp;
+            }
+            else
+            {
+                schema.Op = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["op"]));
+            }
+
+            return schema;
+        }
+
+    }
+
+    //Converter to assign the correct type for a given @contex
+    public class AtContextConverter : JsonConverter<Object[]>
+    {
+
+        public override void WriteJson(JsonWriter writer, Object[]? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override Object[]? ReadJson(JsonReader reader, Type objectType, Object[]? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+            var type = schemaObj.Type;
+
+            switch (type.ToString())
+            {
+                case "Array":
+                    return AtContextTypeArrayFiller(schemaObj, serializer);
+                case "String":
+                    return AtContextTypeUriFiller(schemaObj, serializer);
+
+            }
+            return null;
+
+        }
+
+
+
+        public Object[] AtContextTypeArrayFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+
+            Object[] schema = new Object[schemaObj.Count()];
+
+            schema = schemaObj.ToObject<Object[]>();
+
+            return schema;
+
+        }
+
+        public Object[] AtContextTypeUriFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+
+            Object[] schema = new object[1];
+
+            schema[0] = schemaObj.ToObject<Uri>();
+
+            return schema;
+        }
+
+    }
+
+    //Converter to assign the correct type for a given Op
+    public class StringTypeConverter : JsonConverter<string[]>
+    {
+
+        public override void WriteJson(JsonWriter writer, string[]? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override string[]? ReadJson(JsonReader reader, Type objectType, string[]? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+            var type = schemaObj.Type;
+
+            switch (type.ToString())
+            {
+                case "Array":
+                    return ArrayFiller(schemaObj, serializer);
+                case "String":
+                    return StringFiller(schemaObj, serializer);
+
+            }
+            return null;
+
+        }
+
+
+
+
+
+
+        public string[] ArrayFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+
+            string[] schema = new string[schemaObj.Count()];
+
+           
+
+            schema = schemaObj.ToObject<string[]>();
+
+            return schema;
+
+        }
+
+        public string[] StringFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+            string[] schema = new string[1];
+            string tmp = schemaObj.ToObject<string>();
+            schema[0] = tmp;
+
+            return schema;
+
+
+        }
+    }
+
+    //Converter to assign the correct type for a given Op
+    public class DataSchemaTypeConverter : JsonConverter<DataSchema[]>
+    {
+
+        public override void WriteJson(JsonWriter writer, DataSchema[]? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override DataSchema[]? ReadJson(JsonReader reader, Type objectType, DataSchema[]? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+            var type = schemaObj.Type;
+
+            switch (type.ToString())
+            {
+                case "Object":
+                    return ObjectFiller(schemaObj, serializer);
+                case "Array":
+                    return ArrayFiller(schemaObj, serializer);
+
+            }
+            return null;
+
+        }
+
+
+
+        public DataSchema[] ArrayFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+
+            DataSchema[] schema = new DataSchema[schemaObj.Count()];
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new DataSchemaConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+
+            schema = serializer.Deserialize(new JTokenReader(schemaObj), objectType: typeof(DataSchema[])) as DataSchema[];
+
+
+            return schema;
+
+        }
+
+        public DataSchema[] ObjectFiller(JToken schemaObj, JsonSerializer serializer)
+        {
+            DataSchema[] schema = new DataSchema[1];
+
+            var settings = new JsonSerializerSettings();
+            settings.Converters.Add(new DataSchemaConverter());
+            serializer = JsonSerializer.CreateDefault(settings);
+
+            schema[0] = serializer.Deserialize(new JTokenReader(schemaObj), objectType: typeof(DataSchema)) as DataSchema;
+
+            return schema;
+
+
+        }
+    }
+
+    //Converter to assign the correct InteractionAffordance for a given schema
+    public class InteractionAffordanceConverter : JsonConverter<InteractionAffordance>
+    {
+
+        public override void WriteJson(JsonWriter writer, InteractionAffordance? value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        public override InteractionAffordance? ReadJson(JsonReader reader, Type objectType, InteractionAffordance? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            JToken schemaObj = JToken.Load(reader);
+            if (schemaObj.Type == JTokenType.Null) return null;
+
+            switch (objectType.FullName)
+            {
+                case "WoT_Definitions.PropertyAffordance":
+                    return FillPropertyAffordanceObject(schemaObj, serializer, reader);
+                case "WoT_Definitions.ActionAffordance":
+                    return FillActionAffordanceObject(reader, schemaObj, serializer);
+                case "WoT_Definitions.EventAffordance":
+                    return FillEventAffordanceObject(schemaObj, serializer);
+            }
+            return null;
+        }
+
+        public PropertyAffordance FillPropertyAffordanceObject(JToken schemaObj, JsonSerializer serializer, JsonReader reader)
+        {
+            PropertyAffordance schema = new PropertyAffordance();
+            CommonFiller(schema, schemaObj, serializer);
+
+            if (schemaObj["const"] != null) schema.Const = schemaObj["const"];
+            if (schemaObj["default"] != null) schema.Default = schemaObj["default"];
+            if (schemaObj["unit"] != null) schema.Unit = schemaObj["unit"].ToObject<string>();
+            if (schemaObj["enum"] != null) schema.Enum = schemaObj["enum"].ToObject<Object[]>();
+            if (schemaObj["readOnly"] != null) schema.ReadOnly = schemaObj["readOnly"].ToObject<bool>();
+            if (schemaObj["writeOnly"] != null) schema.WriteOnly = schemaObj["writeOnly"].ToObject<bool>();
+            if (schemaObj["oneOf"] != null) schema.OneOf = serializer.Deserialize(new JTokenReader(schemaObj["oneOf"]), objectType: typeof(DataSchema[])) as DataSchema[];
+            if (schemaObj["format"] != null) schema.Format = schemaObj["format"].ToObject<string>();
+            if (schemaObj["type"] != null) schema.Type = schemaObj["type"].ToObject<string>();
+
+
+            if (schemaObj["observable"] != null) schema.Observable = schemaObj["observable"].ToObject<Boolean>();
+
+            if (schemaObj["forms"] != null) schema.PropertyForm = serializer.Deserialize(new JTokenReader(schemaObj["forms"]), objectType: typeof(PropertyForm[])) as PropertyForm[];
+
+            return schema;
+        }
+
+        public ActionAffordance FillActionAffordanceObject(JsonReader reader, JToken schemaObj, JsonSerializer serializer)
+        {
+            ActionAffordance schema = new ActionAffordance();
+            CommonFiller(schema, schemaObj, serializer);
+            if (schemaObj["input"] != null) schema.Input = serializer.Deserialize(new JTokenReader(schemaObj["input"]), objectType: typeof(DataSchema)) as DataSchema;
+            if (schemaObj["output"] != null) schema.Output = serializer.Deserialize(new JTokenReader(schemaObj["output"]), objectType: typeof(DataSchema)) as DataSchema;
+            if (schemaObj["safe"] != null) schema.Safe = schemaObj["safe"].ToObject<Boolean>();
+            if (schemaObj["idempotent"] != null) schema.Idempotent = schemaObj["idempotent"].ToObject<Boolean>();
+            if (schemaObj["synchronous"] != null) schema.Synchronous = schemaObj["synchronous"].ToObject<Boolean>();
+
+
+
+
+            if (schemaObj["forms"] != null) schema.ActionForm = serializer.Deserialize(new JTokenReader(schemaObj["forms"]), objectType: typeof(ActionForm[])) as ActionForm[];
+
+
+            return schema;
+        }
+
+        public EventAffordance FillEventAffordanceObject(JToken schemaObj, JsonSerializer serializer)
+        {
+            EventAffordance schema = new EventAffordance();
+            CommonFiller(schema, schemaObj, serializer);
+            if (schemaObj["subscription"] != null) schema.Subscription = serializer.Deserialize(new JTokenReader(schemaObj["subscription"]), objectType: typeof(DataSchema)) as DataSchema;
+            if (schemaObj["data"] != null) schema.Data = serializer.Deserialize(new JTokenReader(schemaObj["data"]), objectType: typeof(DataSchema)) as DataSchema;
+            if (schemaObj["dataResponse"] != null) schema.DataResponse = serializer.Deserialize(new JTokenReader(schemaObj["dataResponse"]), objectType: typeof(DataSchema)) as DataSchema;
+            if (schemaObj["cancellation"] != null) schema.Cancellation = serializer.Deserialize(new JTokenReader(schemaObj["cancellation"]), objectType: typeof(DataSchema)) as DataSchema;
+
+            if (schemaObj["forms"] != null) schema.EventForm = serializer.Deserialize(new JTokenReader(schemaObj["forms"]), objectType: typeof(EventForm[])) as EventForm[];
+
+            return schema;
+        }
+
+        public void CommonFiller(InteractionAffordance schema, JToken schemaObj, JsonSerializer serializer)
+        {
+            schema.Description = (string?)schemaObj["description"];
+            schema.Title = (string?)schemaObj["title"];
+
+            //if (schemaObj["@type"] != null) schema.AtType = serializer.Deserialize(new JTokenReader(schemaObj["@type"]), objectType: typeof(AtTypeType)) as AtTypeType;
+
+            if (schemaObj["@type"] != null)
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new StringTypeConverter());
+                serializer = JsonSerializer.CreateDefault(settings);
+                schema.AtType = serializer.Deserialize<string[]>(new JTokenReader(schemaObj["@type"]));
+            }
+
+            if (schemaObj["titles"] != null) schema.Titles = schemaObj["titles"].ToObject<string?[]>();
+            if (schemaObj["descriptions"] != null) schema.Descriptions = schemaObj["descriptions"].ToObject<string?[]>();
+
+            schema.OriginalJson = schemaObj.ToString();
+
+
+
+
+
+        }
+
+
+    }
+
+}
+
+

--- a/TDHelpers/TDHelpers/TDHelpers.csproj
+++ b/TDHelpers/TDHelpers/TDHelpers.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+</PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="WoT">
+      <HintPath>..\..\WoT.Net\WoT\bin\Debug\netstandard2.0\WoT.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
+  </ItemGroup>
+</Project>

--- a/TDHelpers/TDHelpers/TDHelpers.sln
+++ b/TDHelpers/TDHelpers/TDHelpers.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 25.0.1706.8
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDHelpers", "TDHelpers.csproj", "{AC3D89D0-3F4A-4D3F-94C7-710A0CBA7D3A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC3D89D0-3F4A-4D3F-94C7-710A0CBA7D3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC3D89D0-3F4A-4D3F-94C7-710A0CBA7D3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC3D89D0-3F4A-4D3F-94C7-710A0CBA7D3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC3D89D0-3F4A-4D3F-94C7-710A0CBA7D3A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0632D1E1-3F32-4AD7-B7AF-A85DBAFD2625}
+	EndGlobalSection
+EndGlobal

--- a/WoT/WoT-Definitions.cs
+++ b/WoT/WoT-Definitions.cs
@@ -1,12 +1,14 @@
 using System.Collections.Generic;
 using System;
-using Newtonsoft;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using TDHelpers;
 
 namespace WoT_Definitions
 {
     public interface IDataSchema
     {
+        [JsonProperty("@type")]
         string[] AtType { get; set; }
         string Title { get; set; }
         string[] Titles { get; set; }
@@ -25,17 +27,21 @@ namespace WoT_Definitions
     }
     public interface INteractionAffordance
     {
+        [JsonProperty("@type")]
         string[] AtType { get; set; }
         string Title { get; set; }
         string[] Titles { get; set; }
         string Description { get; set; }
         string[] Descriptions { get; set; }
-        Form[] Forms { get; set; }
-        Dictionary<string, DataSchema> UriVariables { get; set; }
+        string OriginalJson { get; set; }
+
 
     }
+
+    [JsonConverter(typeof(DataSchemaConverter))]
     public abstract class DataSchema : IDataSchema
     {
+        [JsonProperty("@type")]
         public string[] AtType { get; set; }
         public string Title { get; set; }
         public string[] Titles { get; set; }
@@ -51,68 +57,99 @@ namespace WoT_Definitions
         public bool WriteOnly { get; set; }
         public string Format { get; set; }
         public string Type { get; }
+
+
+
     }
+
+
     public class ArraySchema : DataSchema
     {
         public new readonly string Type = "array";
         public DataSchema[] Items { get; set; }
-        public uint MinItems { get; set; }
-        public uint MaxItems { get; set; }
+        public uint? MinItems { get; set; }
+        public uint? MaxItems { get; set; }
     }
+     
+
     public class BooleanSchema : DataSchema
     {
         public new readonly string Type = "boolean";
+        public new bool Const { get; set; }
+        public new bool Default { get; set; }
+        public new bool[] Enum { get; set; }
     }
 
     public class NumberSchema : DataSchema
     {
         public new readonly string Type = "number";
-        public double Minimum { get; set; }
-        public double ExclusiveMinimum { get; set; }
-        public double Maximum { get; set; }
-        public double ExclusiveMaximum { get; set; }
-        public double MultipleOf { get; set; }
-
+        public double? Minimum { get; set; }
+        public double? ExclusiveMinimum { get; set; }
+        public double? Maximum { get; set; }
+        public double? ExclusiveMaximum { get; set; }
+        public double? MultipleOf { get; set; }
+        public new double? Const { get; set; }
+        public new double? Default { get; set; }
+        public new double[] Enum { get; set; }  
     }
+
+
     public class IntegerSchema : DataSchema
     {
         public new readonly string Type = "integer";
-        public int Minimum { get; set; }
-        public int ExclusiveMinimum { get; set; }
-        public int Maximum { get; set; }
-        public int ExclusiveMaximum { get; set; }
-        public int MultipleOf { get; set; }
-        public new int Const { get; set; }
-}
+        public int? Minimum { get; set; }
+        public int? ExclusiveMinimum { get; set; }
+        public int? Maximum { get; set; }
+        public int? ExclusiveMaximum { get; set; }
+        public int? MultipleOf { get; set; }
+        public new int? Const { get; set; }
+        public new int? Default { get; set; }
+        public new int[] Enum { get; set; }
+    }
+
+
     public class ObjectSchema : DataSchema
     {
         public new readonly string Type = "object";
         public Dictionary<string, DataSchema> Properties { get; set; }
         public string[] Required { get; set; }
     }
+
+
     public class StringSchema : DataSchema
     {
         public new readonly string Type = "string";
-        public uint MinLength { get; set; }
-        public uint MaxLength { get; set; }
+        public uint? MinLength { get; set; }
+        public uint? MaxLength { get; set; }
         public string Pattern { get; set; }
         public string ContentEncoding { get; set; }
         public string ContentMediaType { get; set; }
+        public new string Const { get; set; }
+        public new string Default { get; set; }
+        public new string[] Enum { get; set; }
+
     }
+
+
     public class NullSchema : DataSchema
     {
         public new readonly string Type = "null";
+
     }
+
+
+    [JsonConverter(typeof(InteractionAffordanceConverter))] 
     public class InteractionAffordance : INteractionAffordance
     {
+        [JsonProperty("@type")]
         public string[] AtType { get; set; }
         public string Title { get; set; }
         public string[] Titles { get; set; }
         public string Description { get; set; }
         public string[] Descriptions { get; set; }
-        public Form[] Forms { get; set; }
-        public Dictionary<string, DataSchema> UriVariables { get; set; }
+        public string OriginalJson { get; set; }
     }
+
     public class PropertyAffordance : InteractionAffordance, IDataSchema
     {
         public object Const { get; set; }
@@ -125,6 +162,8 @@ namespace WoT_Definitions
         public string Format { get; set; }
         public string Type { get; set; }
         public Boolean Observable { get; set; }
+        public PropertyForm[] PropertyForm { get; set; }
+
     }
 
     public class ActionAffordance : InteractionAffordance
@@ -134,6 +173,9 @@ namespace WoT_Definitions
         public Boolean Safe { get; set; }
         public Boolean Idempotent { get; set; }
         public Boolean Synchronous { get; set; }
+        public ActionForm[] ActionForm { get; set; }
+
+
     }
 
     public class EventAffordance : InteractionAffordance
@@ -142,8 +184,11 @@ namespace WoT_Definitions
         public DataSchema Data { get; set; }
         public DataSchema DataResponse { get; set; }
         public DataSchema Cancellation { get; set; }
+        public EventForm[] EventForm { get; set; }
+
     }
 
+    [JsonConverter(typeof(FormConverter))]
     public class Form
     {
         public Uri Href { get; set; }
@@ -151,9 +196,60 @@ namespace WoT_Definitions
         public string ContentCoding { get; set; }
         public string[] Security { get; set; }
         public string[] Scopes { get; set; }
+        public AdditionalExpectedResponse AdditionalExpectedResponse { get; set; }
+        public string Subprotocol { get; set; }
+        public string OriginalJson { get; set; }
+        public string[] Op { get; set; }
 
 
     }
+
+
+    [JsonConverter(typeof(PropertyFormConverter))]
+    public class PropertyForm
+    {
+        public Uri Href { get; set; }
+        public string ContentType { get; set; }
+        public string ContentCoding { get; set; }
+        public string[] Security { get; set; }
+        public string[] Scopes { get; set; }
+        public AdditionalExpectedResponse AdditionalExpectedResponse { get; set; }
+        public string Subprotocol { get; set; }
+        public string OriginalJson { get; set; }
+        public string[] Op { get; set; }
+
+
+    }
+
+    [JsonConverter(typeof(ActionFormConverter))]
+    public class ActionForm
+    {
+        public Uri Href { get; set; }
+        public string ContentType { get; set; }
+        public string ContentCoding { get; set; }
+        public string[] Security { get; set; }
+        public string[] Scopes { get; set; }
+        public AdditionalExpectedResponse AdditionalExpectedResponse { get; set; }
+        public string Subprotocol { get; set; }
+        public string OriginalJson { get; set; }
+        public string[] Op { get; set; }
+
+    }
+
+    [JsonConverter(typeof(EventFormConverter))]
+    public class EventForm
+    {
+        public Uri Href { get; set; }
+        public string ContentType { get; set; }
+        public string ContentCoding { get; set; }
+        public string[] Security { get; set; }
+        public string[] Scopes { get; set; }
+        public AdditionalExpectedResponse AdditionalExpectedResponse { get; set; }
+        public string Subprotocol { get; set; }
+        public string OriginalJson { get; set; }
+        public string[] Op { get; set; }
+    }
+
 
     public struct Link
     {
@@ -162,6 +258,7 @@ namespace WoT_Definitions
         public string Rel { get; set; }
         public Uri Anchor { get; set; }
         public string Uri { get; set; }
+        [JsonConverter(typeof(StringTypeConverter))]
         public string[] Hreflang { get; set; }
     }
 
@@ -197,12 +294,12 @@ namespace WoT_Definitions
         }
     }
 
-    public struct AdditionalExpectedRespone
+    public struct AdditionalExpectedResponse
     {
         public string ContentType { get; set; }
         public Boolean Success { get; set; }
         public string Schema { get; set; }
-        public AdditionalExpectedRespone(string contentType)
+        public AdditionalExpectedResponse(string contentType)
         {
             this.ContentType = contentType;
             this.Success = false;
@@ -210,8 +307,11 @@ namespace WoT_Definitions
         }
     }
 
-    public class SecurityScheme
+
+    [JsonConverter(typeof(SecuritySchemeConverter))]
+    public abstract class SecurityScheme
     {
+        [JsonProperty("@type")]
         public string[] AtType { get; set; }
         public string Description { get; set; }
         public string[] Descriptions { get; set; }
@@ -221,20 +321,24 @@ namespace WoT_Definitions
 
     public class NoSecurityScheme : SecurityScheme
     {
-        public readonly string Scheme = "nosec";
+        public new readonly string Scheme = "nosec";
     }
 
     public class BasicSecurityScheme : SecurityScheme
     {
-        public readonly string Scheme = "basic";
+        public new readonly string Scheme = "basic";
         public string Name { get; set; }
         public string In { get; set; }
     }
 
+    
     public class ThingDescription
     {
-        //[JsonConverter()]
+        [JsonProperty("@context")]
+        [JsonConverter(typeof(AtContextConverter))]
         public Object[] AtContext { get; set; }
+        [JsonProperty("@type")]
+        [JsonConverter(typeof(StringTypeConverter))]
         public string[] AtType { get; set; }
         /**
          * Identifier of the Thing in form of a URI [RFC3986] (e.g., stable URI, temporary and mutable URI, URI with local IP address, URN, etc.).
@@ -257,12 +361,17 @@ namespace WoT_Definitions
         public Dictionary<string, EventAffordance> Events { get; set; }
         public Link[] Links { get; set; }
         public Form[] Forms { get; set; }
+        [JsonConverter(typeof(StringTypeConverter))]
         public string[] Security { get; set; }
         public Dictionary<string, SecurityScheme> SecurityDefinitions { get; set; }
-        public Uri[] Profile { get; set; }
+        [JsonConverter(typeof(StringTypeConverter))]
+        public string[] Profile { get; set; }
         public Dictionary<string, DataSchema> SchemaDefinitions { get; set; }
         public Dictionary<string, DataSchema> UriVariables { get; set; }
 
+        //any properties not matching the explicitly defined in properties will be captured in the AdditionalProperties dictionary.
+        [JsonExtensionData]
+        public Dictionary<string, JToken> AdditionalProperties { get; set; }
     }
 
 }

--- a/WoT/WoT.csproj
+++ b/WoT/WoT.csproj
@@ -8,6 +8,12 @@
     <PackageReference Include="JsonSchema.Net" Version="5.4.0" />
     <PackageReference Include="JsonSchema.Net.CodeGeneration" Version="0.1.3" />
     <PackageReference Include="JsonSchema.Net.Generation" Version="3.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="TDHelpers">
+      <HintPath>..\..\TDHelpers\TDHelpers\bin\Debug\netstandard2.0\TDHelpers.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- TDHelpers library is formed to create listed converters: 
           - DataSchemaConverter -> Returns the corresponding _DataSchema_ for a given schema.
           - SecuritySchemeConverter -> Returns the corresponding _SecurityScheme_ for a given scheme.
           - FormConverter
           - PropertyFormConverter -> Manages the default _Op_ value in _PropertyForm_ (still a TODO).
           - ActionFormConverter  ->  Manages the default _Op_ value in _ActionForm_
           - EventFormConverter -> Manages the default _Op_ value in _EventForm_.
           - AtContextConverter
           - StringTypeConverter -> Called for properties that can be either _string_ or _string[]_, and it returns _string[]_.
           - DataSchemaTypeConverter -> Called for properties that can be either _DataSchema_ or _DataSchema[]_, and it returns _DataSchema[]_.
           - InteractionAffordanceConverter -> Returns corresponding _InteractionAffordance_
- Other added functionalities:
           - Handling properties with defaults according to [https://www.w3.org/TR/wot-thing-description11/#sec-default-values](url)
           - Overriding enum, const and default for DataSchemas with settled type of enum, const and default.
           - Converters are added as an attribute
           - Additional properties Handling for TD
           - Storing the related part of TD as a string for Forms and Interaction Affordances
           - Missing properties are added
           - For validation see README.md in TDHelpers

